### PR TITLE
52-only-run-workflow-on-relevant-files

### DIFF
--- a/.github/workflows/python-wf.yml
+++ b/.github/workflows/python-wf.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - 'app/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
only run the workflow on commits to pull requests that don't have changes to the app directory.

but on merges to main, we will still run every job.